### PR TITLE
Feature: set tags to a file

### DIFF
--- a/lib/src/cloudinary_file.dart
+++ b/lib/src/cloudinary_file.dart
@@ -26,6 +26,9 @@ class CloudinaryFile {
   /// [CloudinaryResourceType.Raw],
   final CloudinaryResourceType resourceType;
 
+  /// File tags
+  final List<String> tags;
+
   /// [CloudinaryFile] instance
   const CloudinaryFile({
     this.byteData,
@@ -33,6 +36,7 @@ class CloudinaryFile {
     this.identifier,
     this.url,
     @required this.resourceType,
+    this.tags
   }) : assert(
             (byteData == null && file != null) ||
                 (byteData != null && file == null) ||
@@ -44,11 +48,13 @@ class CloudinaryFile {
     Future<ByteData> byteData, {
     String identifier,
     CloudinaryResourceType resourceType: CloudinaryResourceType.Auto,
+    List<String> tags
   }) async =>
       CloudinaryFile.fromByteData(
         await byteData,
         identifier: identifier,
         resourceType: resourceType,
+        tags: tags
       );
 
   /// Instantiate [CloudinaryFile] from [ByteData]
@@ -56,28 +62,33 @@ class CloudinaryFile {
     ByteData byteData, {
     String identifier,
     CloudinaryResourceType resourceType: CloudinaryResourceType.Auto,
+    List<String> tags
   }) =>
       CloudinaryFile(
           byteData: byteData,
           identifier: identifier,
-          resourceType: resourceType);
+          resourceType: resourceType,
+          tags: tags);
 
   /// Instantiate [CloudinaryFile] from [File]
   factory CloudinaryFile.fromFile(
     File file, {
     String identifier,
     CloudinaryResourceType resourceType: CloudinaryResourceType.Auto,
+    List<String> tags
   }) =>
       CloudinaryFile(
         file: file,
         identifier: identifier ??= file.path.split('/').last,
         resourceType: resourceType,
+        tags: tags
       );
 
   /// Instantiate [CloudinaryFile] from an external url
   factory CloudinaryFile.fromUrl(
     String url, {
     CloudinaryResourceType resourceType: CloudinaryResourceType.Auto,
+    List<String> tags
   }) =>
       CloudinaryFile(
         url: url,

--- a/lib/src/cloudinary_public.dart
+++ b/lib/src/cloudinary_public.dart
@@ -58,6 +58,12 @@ class CloudinaryPublic {
       'upload_preset': _uploadPreset,
     });
 
+    if (file.tags != null && file.tags.isNotEmpty) {
+      formData.fields.add(MapEntry<String, String>(
+        'tags', file.tags.join(',')
+      ));
+    }
+
     /// throws DioError
     final res = await dioClient.post(
       '$_baseUrl/$_cloudName/${describeEnum(file.resourceType).toLowerCase()}/upload',

--- a/lib/src/cloudinary_response.dart
+++ b/lib/src/cloudinary_response.dart
@@ -29,7 +29,7 @@ class CloudinaryResponse {
       url: data['url'],
       secureUrl: data['secure_url'],
       originalFilename: data['original_filename'],
-      tags: (data['tags'] as List).map((tag) => tag as String).toList()
+      tags: data['tags'] != null ? (data['tags'] as List).map((tag) => tag as String).toList() : []
     );
   }
 

--- a/lib/src/cloudinary_response.dart
+++ b/lib/src/cloudinary_response.dart
@@ -6,6 +6,7 @@ class CloudinaryResponse {
   final String url;
   final String secureUrl;
   final String originalFilename;
+  final List<String> tags;
   final bool fromCache;
 
   CloudinaryResponse({
@@ -15,6 +16,7 @@ class CloudinaryResponse {
     this.url,
     this.secureUrl,
     this.originalFilename,
+    this.tags,
     this.fromCache: false,
   });
 
@@ -27,6 +29,7 @@ class CloudinaryResponse {
       url: data['url'],
       secureUrl: data['secure_url'],
       originalFilename: data['original_filename'],
+      tags: (data['tags'] as List).map((tag) => tag as String).toList()
     );
   }
 
@@ -39,6 +42,7 @@ class CloudinaryResponse {
       url: url,
       secureUrl: secureUrl,
       originalFilename: originalFilename,
+      tags: tags,
       fromCache: true,
     );
   }
@@ -51,7 +55,8 @@ class CloudinaryResponse {
       'created_at': createdAt.toString(),
       'url': url,
       'secure_url': secureUrl,
-      'original_filename': originalFilename
+      'original_filename': originalFilename,
+      'tags' : tags
     };
   }
 

--- a/test/cloudinary_public_test.dart
+++ b/test/cloudinary_public_test.dart
@@ -75,6 +75,7 @@ void main() {
     final file = CloudinaryFile.fromFile(
       tempFile,
       resourceType: CloudinaryResourceType.Image,
+      tags: ['trip']
     );
     final res = await cloudinary.uploadFile(file);
     expect(res, TypeMatcher<CloudinaryResponse>());


### PR DESCRIPTION
Set tags to a file so you can take advantage of the Cloudinary filtering options. More info [here](https://support.cloudinary.com/hc/en-us/articles/202520142-How-can-I-tag-an-image-).