### PR TITLE
Override default upload_preset when uploading file(s)

### DIFF
--- a/lib/src/cloudinary_public.dart
+++ b/lib/src/cloudinary_public.dart
@@ -40,12 +40,13 @@ class CloudinaryPublic {
   }
 
   /// Upload multiple files together
-  Future<List<CloudinaryResponse>> uploadFiles(List<CloudinaryFile> files) {
-    return Future.wait(files.map((file) => uploadFile(file)));
+  Future<List<CloudinaryResponse>> uploadFiles(List<CloudinaryFile> files, {String uploadPreset}) {
+    return Future.wait(files.map((file) => uploadFile(file, uploadPreset: uploadPreset)));
   }
 
   /// Upload the cloudinary file to using the public api
-  Future<CloudinaryResponse> uploadFile(CloudinaryFile file) async {
+  /// Override the default upload preset (when [CloudinaryPublic] is instantiated) with this one (if specified).
+  Future<CloudinaryResponse> uploadFile(CloudinaryFile file, {String uploadPreset}) async {
     if (cache) {
       assert(file.identifier != null, 'identifier is required for caching');
 
@@ -55,7 +56,7 @@ class CloudinaryPublic {
 
     FormData formData = FormData.fromMap({
       'file': file.toMultipartFile() ?? file.url,
-      'upload_preset': _uploadPreset,
+      'upload_preset': uploadPreset ?? _uploadPreset,
     });
 
     if (file.tags != null && file.tags.isNotEmpty) {
@@ -81,13 +82,13 @@ class CloudinaryPublic {
 
   /// Upload the file using [uploadFile]
   Future<CloudinaryResponse> uploadFutureFile(
-      Future<CloudinaryFile> file) async {
-    return uploadFile(await file);
+      Future<CloudinaryFile> file, {String uploadPreset}) async {
+    return uploadFile(await file, uploadPreset: uploadPreset);
   }
 
   /// Upload multiple files using simultaneously [uploadFutureFile]
   Future<List<CloudinaryResponse>> multiUpload(
-      List<Future<CloudinaryFile>> files) async {
-    return Future.wait(files.map((file) => uploadFutureFile(file)));
+      List<Future<CloudinaryFile>> files, {String uploadPreset}) async {
+    return Future.wait(files.map((file) => uploadFutureFile(file, uploadPreset: uploadPreset)));
   }
 }

--- a/test/cloudinary_public_test.dart
+++ b/test/cloudinary_public_test.dart
@@ -86,6 +86,28 @@ void main() {
     expect(secondUpload.fromCache, true);
   });
 
+  test('uploads an image file overriding the upload_preset', () async {
+    final cloudinary = CloudinaryPublic(
+      cloudName,
+      uploadPreset,
+      dioClient: client,
+      cache: true,
+    );
+
+    final file = CloudinaryFile.fromFile(tempFile.path,
+        resourceType: CloudinaryResourceType.Image, tags: ['trip']);
+    final res = await cloudinary.uploadFile(file);
+    expect(res, TypeMatcher<CloudinaryResponse>());
+
+    // test toString
+    expect(res.toString(), res.toMap().toString());
+
+    // test cache
+    final secondUpload = await cloudinary.uploadFile(file, uploadPreset: 'another_preset');
+    expect(secondUpload, TypeMatcher<CloudinaryResponse>());
+    expect(secondUpload.fromCache, true);
+  });
+
   test('upload multiple image files', () async {
     final cloudinary = CloudinaryPublic(
       cloudName,


### PR DESCRIPTION
In the project I'm working on there are multiple upload_presets that are used depending on the section of the app the user is uploading a file. This is a way to specify an upload_preset directly when uploading it overriding the one specified when instantiating CloudinaryPublic.