### PR TITLE
Add import type_data

### DIFF
--- a/lib/src/cloudinary_file.dart
+++ b/lib/src/cloudinary_file.dart
@@ -1,6 +1,7 @@
 import 'package:cloudinary_public/cloudinary_public.dart';
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
+import 'dart:typed_data';
 
 /// The recognised file class to be used for this package
 class CloudinaryFile {


### PR DESCRIPTION
An error occured before because the ByteData datatype isn't imported.

src/flutter/.pub-cache/hosted/pub.dartlang.org/cloudinary_public-0.13.0/lib/src/cloudinary_file.dart:80:5: Error: 'ByteData' isn't a type.
    ByteData byteData, {

    ^^^^^^^^
    
Fixed by adding import 'dart:typed_data';

![image](https://user-images.githubusercontent.com/43689683/194598858-5c6ab1c9-8e2e-44b4-840c-8eb78851ad8d.png)
